### PR TITLE
ci: label dependabot PRs with area:tooling + effort:XS

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,9 @@ updates:
     commit-message:
       prefix: chore
       include: scope
+    labels:
+      - "area:tooling"
+      - "effort:XS"
 
   - package-ecosystem: npm
     directory: /
@@ -37,3 +40,6 @@ updates:
     commit-message:
       prefix: chore
       include: scope
+    labels:
+      - "area:tooling"
+      - "effort:XS"


### PR DESCRIPTION
## Summary

Add default `labels:` to both Dependabot ecosystems (github-actions, npm) so every dependency-update PR lands pre-tagged with `area:tooling` + `effort:XS`.
The labels were created in the repo out-of-band (`gh label create`); Dependabot silently drops labels that don't exist, so they must pre-exist (they do).

## Test plan

- [x] `dependabot.yml` is config-only — no runtime/script change
- [x] YAML structure validated; both ecosystems carry identical `labels:` blocks