### PR TITLE
chore: ignore Claude worktrees directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ dist/
 
 # personal Claude Code overrides (the committed .claude/settings.json is the example)
 .claude/settings.local.json
+
+# Git worktrees created via Claude Code's EnterWorktree (each lives under .claude/worktrees/)
+/.claude/worktrees


### PR DESCRIPTION
## Summary

Add `.claude/worktrees/` to `.gitignore` to keep local Claude Code worktrees out of version control.

## Test plan

* [x] Verified `.claude/worktrees/` is ignored by git

## Decisions worth noting (optional — delete if not applicable)

* Kept Claude worktrees as local-only files since they are development artifacts.