### PR TITLE
fix: collect and report all unknown options

### DIFF
--- a/.changeset/wacky-bears-carry.md
+++ b/.changeset/wacky-bears-carry.md
@@ -1,0 +1,5 @@
+---
+'@inbrace-tech/tokenline': patch
+---
+
+Fix CLI parser to collect and report all unknown options instead of just the last one.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -39,7 +39,7 @@ function parseArgs(argv: string[]): Options {
     purge: false,
     help: false,
     version: false,
-    unknown: null,
+    unknown: [],
   }
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i]
@@ -69,7 +69,7 @@ function parseArgs(argv: string[]): Options {
         out.version = true
         break
       default:
-        if (a !== undefined && a.startsWith('-')) out.unknown = a
+        if (a !== undefined && a.startsWith('-')) out.unknown.push(a)
         else if (a !== undefined) out._.push(a)
     }
   }
@@ -105,7 +105,9 @@ ${bold('Notes')}
 
 function main(): void {
   const opts = parseArgs(process.argv.slice(2))
-  if (opts.unknown) warn(`ignoring unknown option: ${opts.unknown}`)
+  if (opts.unknown.length > 0) {
+    opts.unknown.forEach((u) => warn(`ignoring unknown option: ${u}`))
+  }
   if (opts.version) {
     console.log(PKG.version)
     return

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -7,7 +7,7 @@ export interface Options {
   purge: boolean
   help: boolean
   version: boolean
-  unknown: string | null
+  unknown: string[]
 }
 
 export interface StatusLineBlock {


### PR DESCRIPTION
## Summary

Fixed a bug in the CLI argument parser where multiple unknown flags (e.g., `--foo --bar`) would overwrite each other, resulting in only the last unknown option being reported to the user. The `unknown` property is now an array that accumulates all unrecognized flags.

## Test plan

- [x] Ran `npx tokenline init --foo --bar` locally and verified both warnings are printed.
- [x] Confirmed the `pnpm build` succeeds with the new type signatures.
- [x] `shellcheck -s bash tokenline.sh` is clean

## Decisions worth noting

- Maintained the `warn` log level for unknown options instead of throwing a hard error, as extra flags do not strictly prevent the core execution path.