### PR TITLE
feat: default to local project install and update README for DX

### DIFF
--- a/.changeset/afraid-bats-occur.md
+++ b/.changeset/afraid-bats-occur.md
@@ -1,0 +1,5 @@
+---
+'@inbrace-tech/tokenline': minor
+---
+
+Changed default installation to local project (.claude), added --global flag, and revamped README with quick start onboarding and Prompt Caching guide.

--- a/README.md
+++ b/README.md
@@ -6,40 +6,75 @@
 ![Platform](https://img.shields.io/badge/platform-Linux%20%7C%20WSL2-blue)
 ![Shell](https://img.shields.io/badge/shell-bash%204%2B-lightgrey)
 
-`tokenline` turns the one-line status bar of your AI coding CLI into a live cockpit:
-which model you're on, how much context you've burned, how long your prompt cache
-stays hot, how many tokens you're **saving** by reusing it, and how close you are to
-your 5h / 7d rate limits.
+## Quickstart
 
-It is **cross-CLI** (Claude Code, Antigravity) and **cross-provider** (Anthropic,
-Gemini) — detecting the active client and model provider at runtime and adjusting
-the cost equivalents accordingly.
+### 1. Install (via npm)
+If you have **Node 18+**, run this inside your project repository to configure the statusline locally.
+
+```bash
+npx @inbrace-tech/tokenline init
+```
+
+*Want it globally for all your projects? Add `--global` to the command.*
+```bash
+npx @inbrace-tech/tokenline init --global
+```
+
+### 2. Restart your CLI
+
+Simply restart Claude Code or Antigravity, and your new statusline will be live.
+
+---
 
 ## Preview
 
 ![Tokenline Preview](https://raw.githubusercontent.com/inbrace-tech/tokenline/main/assets/tokenline.png)
 
 - **Line 1** — model · context used (tokens + %) · cache TTL with a live HOT→COLD countdown.
-- **Line 2** — per-turn token economics: `read / write / new / output`, the equivalent
-  billed tokens (`eq`), and the **`saving %`** you get from prompt caching.
-- **Line 3** — 5h and 7d rate-limit bars with reset ETA and a **pace marker**
-  (`!!` = you're burning the window faster than it refills).
+- **Line 2** — per-turn token economics: `read / write / new / output`, the equivalent billed tokens (`eq`), and the **`saving %`** you get from prompt caching.
+- **Line 3** — 5h and 7d rate-limit bars with reset ETA and a **pace marker** (`!!` = you're burning the window faster than it refills).
 
-> Lines 2 and 3 appear only when there's something to show (a turn happened, limits
-> exist), so the bar stays quiet when idle.
+> Lines 2 and 3 appear only when there's something to show (a turn happened, limits exist), so the bar stays quiet when idle.
+
+## About
+
+`tokenline` turns the one-line status bar of your AI coding CLI into a live cockpit:
+* Which model you're on.
+* How much context you've burned.
+* How long your prompt cache stays hot.
+* How many tokens you're saving by reusing it.
+* How close you are to your 5h / 7d rate limits.
+
+It is **cross-CLI** (Claude Code, Antigravity) and **cross-provider** (Anthropic, Gemini) — detecting the active client and model provider at runtime and adjusting the cost equivalents accordingly.
 
 ## Why tokenline?
 
-Most statuslines show the model and the context bar. `tokenline` adds the two things
-that actually drive cost and flow on long agent sessions:
+Most statuslines show the model and the context bar. `tokenline` adds the two things that actually drive cost and flow on long agent sessions:
 
-- **Cache visibility.** Anthropic and Gemini bill cached input tokens at a fraction of
-  the price — but the cache expires. `tokenline` shows the TTL countdown (5m or 1h,
-  detected from the data) so you know whether your next turn lands warm or cold.
-- **Savings, quantified.** The `saving %` makes the value of prompt caching concrete
-  instead of invisible.
-- **Rate-limit pacing.** The `!!` marker warns you when you're on track to hit the 5h
-  or 7d ceiling before it resets.
+- **Cache visibility.** Anthropic and Gemini bill cached input tokens at a fraction of the price — but the cache expires. `tokenline` shows the TTL countdown (5m or 1h, detected from the data) so you know whether your next turn lands warm or cold.
+- **Savings, quantified.** The `saving %` makes the value of prompt caching concrete instead of invisible.
+- **Rate-limit pacing.** The `!!` marker warns you when you're on track to hit the 5h or 7d ceiling before it resets.
+
+## A 30-second guide to Prompt Caching
+
+LLMs are stateless — by default, they must reread your entire codebase context (system prompt, tools, file history) on *every single turn* before generating a response. This phase (Prefill) is slow and expensive.
+
+**Prompt Caching** solves this by saving that processed state in the provider's memory:
+- **Cache Write (Cold):** The model reads everything and stores the state. This costs slightly more than base tokens.
+- **Cache Hit (Warm):** If your prompt prefix matches the cached state exactly, the model skips the reading phase. This is **~90% cheaper** and starts responding almost instantly.
+- **TTL (Time-To-Live):** The cache operates as a **sliding window**. Every cache hit resets the countdown to its full duration for free. The secret to minimizing rate-limit drain is adjusting your workflow pace to keep the cache continuously **HOT**.
+
+### 💡 Pro-tip: Forcing a 5m TTL to save rate limits
+
+Anthropic's rules for assigning cache TTLs are dynamic and can change without notice (e.g., historically granting a 1-hour TTL to Claude.ai Max users). This is exactly why `tokenline` is valuable: it doesn't guess your TTL based on your plan. It parses the actual CLI telemetry in real-time to detect whether your last turn was processed as a 5-minute or 1-hour write, and adapts the UI countdown and token economics accordingly.
+
+If `tokenline` reveals you are getting 1-hour cache writes, keep in mind they burn **2x** the tokens from your 5h/7d rate limit (compared to 1.25x for a 5-minute write). If you find this is exhausting your quota too quickly—especially when running multiple subagents that cool down fast—you can force the CLI to fall back to the cheaper 5-minute writes by adding this to your `.claude/settings.json`:
+
+```json
+"env": {
+  "FORCE_PROMPT_CACHING_5M": "1"
+}
+```
 
 ## Requirements
 
@@ -52,29 +87,11 @@ v1 targets **Linux / WSL2**:
 > macOS and Windows support are on the [roadmap](#roadmap). `install.sh` checks all of
 > the above and tells you exactly what's missing.
 
-## Install
-
-### With npm (recommended)
-
-If you have **Node 18+**, one command installs the script and wires it into your
-Claude Code settings:
-
-```bash
-npx @inbrace-tech/tokenline init
-```
-
-It copies `tokenline.sh` to `~/.claude/` and adds the `statusLine` block to
-`~/.claude/settings.json`. Use `--project` to configure the current project
-instead of your global settings, and `--dry-run` to preview without writing.
-Then restart Claude Code.
-
-> The statusline runs as `bash tokenline.sh` — Node is used only at install
-> time, never in the per-second hot path. `jq` is still required at runtime.
+## Advanced Installation
 
 ### Without Node (clone + install.sh)
 
-No Node? Clone the repo and run the dependency checker, which prints a
-ready-to-paste snippet:
+No Node? Clone the repo and run the dependency checker, which prints a ready-to-paste snippet:
 
 ```bash
 git clone https://github.com/inbrace-tech/tokenline.git
@@ -82,8 +99,7 @@ cd tokenline
 ./install.sh
 ```
 
-Add the printed block to `~/.claude/settings.json` (global) or your project's
-`.claude/settings.json`, inside the top-level object:
+Add the printed block to your project's `.claude/settings.json` (or `~/.claude/settings.json` for global), inside the top-level object:
 
 ```json
 "statusLine": {
@@ -97,34 +113,24 @@ Then restart Claude Code.
 
 ### What the installer does
 
-`npx @inbrace-tech/tokenline init` is deliberately transparent about touching
-your config:
+`npx @inbrace-tech/tokenline init` is deliberately transparent about touching your config:
 
 - **Writes** `tokenline.sh` to `~/.claude/` (or `./.claude/` with `--project`).
-- **Merges** only the `statusLine` key into `settings.json` — every other
-  setting is preserved.
+- **Merges** only the `statusLine` key into `settings.json` — every other setting is preserved.
 - **Backs up** `settings.json` to `settings.json.bak` before writing.
-- **Never clobbers** invalid JSON: if it can't parse your `settings.json`, it
-  stops and prints the block to paste manually.
-- Is **idempotent**, and won't replace a different existing `statusLine` unless
-  you pass `--force`.
+- **Never clobbers** invalid JSON: if it can't parse your `settings.json`, it stops and prints the block to paste manually.
+- Is **idempotent**, and won't replace a different existing `statusLine` unless you pass `--force`.
 
-Other commands: `doctor` (check dependencies and config, change nothing) and
-`uninstall` (remove the block; `--purge` also deletes the script).
+Other commands: `doctor` (check dependencies and config, change nothing) and `uninstall` (remove the block; `--purge` also deletes the script).
 
 ### Antigravity CLI
 
-`tokenline` detects the Antigravity CLI from the transcript path and switches to its
-provider equivalents automatically. Point Antigravity's statusline command at the same
+`tokenline` detects the Antigravity CLI from the transcript path and switches to its provider equivalents automatically. Point Antigravity's statusline command at the same
 `tokenline.sh` — no extra flags needed.
 
 ## How it works
 
-On every refresh the host CLI pipes a JSON snapshot of the session to the script over
-stdin. `tokenline` parses it in a single `jq` pass (to keep the per-second refresh
-cheap), reads the last turn's timestamp from the transcript to drive the cache
-countdown, and renders up to three lines. Per-turn timestamps are cached in a
-per-user `0700` directory under `$XDG_RUNTIME_DIR` (tmpfs, cleared on logout).
+On every refresh the host CLI pipes a JSON snapshot of the session to the script over stdin. `tokenline` parses it in a single `jq` pass (to keep the per-second refresh cheap), reads the last turn's timestamp from the transcript to drive the cache countdown, and renders up to three lines. Per-turn timestamps are cached in a per-user `0700` directory under `$XDG_RUNTIME_DIR` (tmpfs, cleared on logout).
 
 ## Troubleshooting
 
@@ -145,16 +151,11 @@ per-user `0700` directory under `$XDG_RUNTIME_DIR` (tmpfs, cleared on logout).
 
 ## Contributing
 
-Issues and PRs are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md). The CI runs
-[ShellCheck](https://www.shellcheck.net/) on every push, so please keep the script
-lint-clean.
+Issues and PRs are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md). The CI runs [ShellCheck](https://www.shellcheck.net/) on every push, so please keep the script lint-clean.
 
 ## About Inbrace
 
-`tokenline` is built and maintained by **Inbrace** — a software house based in
-Campinas, Brazil, building software with technical and human responsibility. We work
-where security is non-negotiable and architecture is treated as a strategic asset:
-intentional engineering, grounded decisions, and systems built to last.
+`tokenline` is built and maintained by **Inbrace** — a software house based in Campinas, Brazil, building software with technical and human responsibility. We work where security is non-negotiable and architecture is treated as a strategic asset: intentional engineering, grounded decisions, and systems built to last.
 
 > Inbrace. The human side of software.
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,8 +6,8 @@
 // your Claude Code settings.json. The statusline itself runs as
 // `bash tokenline.sh` — there is NO Node in the per-second hot path.
 //
-//   npx @inbrace-tech/tokenline init              # install into ~/.claude
-//   npx @inbrace-tech/tokenline init --project    # install into ./.claude
+//   npx @inbrace-tech/tokenline init              # install into ~/.claude (project)
+//   npx @inbrace-tech/tokenline init --global     # install into ./.claude (global)
 //   npx @inbrace-tech/tokenline doctor            # check deps, change nothing
 //   npx @inbrace-tech/tokenline uninstall         # remove the statusLine block
 //
@@ -33,7 +33,7 @@ function parseArgs(argv: string[]): Options {
   const out: Options = {
     _: [],
     dir: null,
-    project: false,
+    global: false,
     dryRun: false,
     force: false,
     purge: false,
@@ -47,9 +47,8 @@ function parseArgs(argv: string[]): Options {
       case '--dir':
         out.dir = argv[++i] ?? null
         break
-      case '--project':
-      case '--local':
-        out.project = true
+      case '--global':
+        out.global = true
         break
       case '--dry-run':
         out.dryRun = true
@@ -89,7 +88,7 @@ ${bold('Commands')}
   uninstall     Remove the tokenline statusLine block from settings
 
 ${bold('Options')}
-  --project     Target ./.claude (project) instead of ~/.claude (global)
+  --global      Target ~/.claude (global) instead of ./.claude (project)
   --dir <path>  Write tokenline.sh to a custom directory
   --dry-run     Show what would happen without writing anything
   --force       Proceed on an unsupported platform / replace an existing statusLine

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -8,13 +8,16 @@ export function cmdDoctor(): void {
   checkPlatform()
   checkBash()
   checkJq()
-  const scopes: Array<{ label: string; project: boolean }> = [
-    { label: 'global', project: false },
-    { label: 'project', project: true },
+
+  const scopes: Array<{ label: string; global: boolean }> = [
+    { label: 'project', global: false },
+    { label: 'global', global: true },
   ]
+
   for (const scope of scopes) {
-    const f = settingsTarget({ project: scope.project, dir: null })
+    const f = settingsTarget({ global: scope.global, dir: null })
     const s = readSettings(f)
+
     if (s.exists && s.data && isTokenlineCommand(s.data.statusLine?.command)) {
       ok(`${scope.label} settings: tokenline configured (${f})`)
     } else if (s.exists && s.data === null) {

--- a/src/core/paths.ts
+++ b/src/core/paths.ts
@@ -8,7 +8,7 @@ import type { Target } from '../shared/types'
 export const SCRIPT_SOURCE = join(__dirname, '..', 'tokenline.sh')
 
 export const claudeDir = (o: Target): string =>
-  o.project ? resolve('.claude') : join(homedir(), '.claude')
+  o.global ? join(homedir(), '.claude') : resolve('.claude')
 export const scriptTarget = (o: Target): string =>
   o.dir ? resolve(o.dir, 'tokenline.sh') : join(claudeDir(o), 'tokenline.sh')
 export const settingsTarget = (o: Target): string =>

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,7 +1,7 @@
 export interface Options {
   _: string[]
   dir: string | null
-  project: boolean
+  global: boolean
   dryRun: boolean
   force: boolean
   purge: boolean
@@ -27,4 +27,4 @@ export interface ReadResult {
   raw?: string
 }
 
-export type Target = Pick<Options, 'project' | 'dir'>
+export type Target = Pick<Options, 'global' | 'dir'>


### PR DESCRIPTION
## Summary

This PR radically improves the onboarding DX. 
- **CLI:** Changes the default installation target to the local project (`./.claude/`) rather than global. Replaced the `--project` flag with a `--global` flag.
- **README:** Moved the Quickstart guide to the very top to reduce initial friction. Converted the intro paragraph into highly scannable bullets.
- **Docs:** Added a "30-second guide to Prompt Caching" section to educate users on the sliding window TTL, the difference between cold/warm cache, and the `FORCE_PROMPT_CACHING_5M` tip to save rate limits.

## Decisions worth noting

- **Dynamic TTL Explanation:** Explicitly highlighted that Anthropic's TTL assignment is dynamic and that `tokenline` reads the *actual* telemetry payload rather than guessing based on plan documentation.

## Out of scope

- Changing the `tokenline.sh` bash script behavior — this PR strictly focuses on the TS installer config and README documentation.