### PR TITLE
fix(docs): correct installer paths and terminology in README

### DIFF
--- a/.changeset/fix-installer-paths.md
+++ b/.changeset/fix-installer-paths.md
@@ -1,0 +1,5 @@
+---
+"@inbrace-tech/tokenline": patch
+---
+
+fix(docs): update installer README text to reflect local-first default and --global flag

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Then restart Claude Code.
 
 `npx @inbrace-tech/tokenline init` is deliberately transparent about touching your config:
 
-- **Writes** `tokenline.sh` to `~/.claude/` (or `./.claude/` with `--project`).
+- **Writes** `tokenline.sh` to `./.claude/` (or `~/.claude/` with `--global`).
 - **Merges** only the `statusLine` key into `settings.json` — every other setting is preserved.
 - **Backs up** `settings.json` to `settings.json.bak` before writing.
 - **Never clobbers** invalid JSON: if it can't parse your `settings.json`, it stops and prints the block to paste manually.


### PR DESCRIPTION
## Summary

Hotfix for the README. The "What the installer does" section was still referencing the old global-first behavior (`~/.claude/` and `--project`). Updated it to correctly reflect the new local-first default (`./.claude/`) and the `--global` flag released in the previous minor bump.

## Decisions worth noting (optional)

- Shipped as a `patch` bump since it's a documentation correction for a feature that was already released.