### PR TITLE
ci: use a conventional-commit title for the changesets release PR

### DIFF
--- a/.changeset/release-pr-title.md
+++ b/.changeset/release-pr-title.md
@@ -1,0 +1,6 @@
+---
+---
+
+CI-only change: set a conventional-commits `title`/`commit` on the changesets
+release PR so the "PR title (semantic)" check passes. No runtime or package
+change, so this is an intentionally empty changeset (no version bump).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,9 @@
 # ─────────────────────────────────────────────────────────────────────────────
 # Release — triggered on pushes to main.
 # Reads pending .changeset/*.md files, bumps versions, generates CHANGELOG.md,
-# creates a "Version Packages" PR, and publishes to NPM when merged.
+# creates a "chore: version packages" PR, and publishes to NPM when merged.
+# The PR title/commit are set to a conventional-commits form (lowercase subject)
+# so the "PR title (semantic)" check passes on the auto-generated release PR.
 # ─────────────────────────────────────────────────────────────────────────────
 name: Release
 
@@ -33,6 +35,10 @@ jobs:
         with:
           # This triggers the "release" script we added to package.json
           publish: pnpm run release
+          # Conventional-commits title for the auto-generated release PR, so the
+          # "PR title (semantic)" check passes (it requires a lowercase subject).
+          title: "chore: version packages"
+          commit: "chore: version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## What changes

Defines the `title` and `commit` inputs of `changesets/action` (in `.github/workflows/release.yml`) as **`chore: version packages`**, instead of the default `Version Packages`.

## Why

The **PR title (semantic)** workflow validates every PR title against conventional commits and requires the *subject* to be lowercase (`subjectPattern: ^(?![A-Z]).+$`). The default `Version Packages` fails for two reasons: it does not have a valid *type* and starts with an uppercase `V`. Because of that, every automatic release PR (e.g. #25, #21, #19) was failing the title check.

`chore: version packages` preserves the meaning of the default, uses an allowed *type* (`chore`), and has a lowercase *subject* --- passing the check. The same value was applied to `commit` so the `git log` remains consistent after the squash merge.

## Changeset

A **CI-only** change --- it does not touch `tokenline.sh`, `install.sh`, or the npm package. Therefore, it uses an **empty changeset** (with no version bump), avoiding publishing a no-op npm release.
`pnpm changeset status` confirms: *NO packages to be bumped*.

## Verification

-   `python3 -c "yaml.safe_load(...)"` → `release.yml` is valid YAML
-   `pnpm changeset status` → no packages to version (empty changeset OK)

Closes #30