### PR TITLE
test: cover the remaining readSettings branches (empty file, valid json)

### DIFF
--- a/src/core/settings.spec.ts
+++ b/src/core/settings.spec.ts
@@ -4,9 +4,11 @@ import { join } from 'node:path'
 
 import { readSettings } from './settings'
 
-// readSettings is the first link in the settings.json patching contract (#5):
-// it must report an absent file and refuse to parse invalid JSON (data: null)
-// so callers never clobber a file they can't understand.
+// readSettings is the first link in the settings.json patching contract (#5).
+// It has four branches, all covered here: an absent file (exists: false), an
+// empty/whitespace file (empty settings, raw preserved), a valid JSON file
+// (parsed data + raw), and invalid JSON (data: null) — the last so callers
+// never clobber a file they can't understand.
 //
 // This spec doubles as the pattern for the fuller contract tests: drive real
 // files under a throwaway temp dir and clean up after each case, so no test
@@ -36,4 +38,30 @@ it('refuses to parse invalid JSON, returning data: null (never clobber)', () => 
 
   expect(result.exists).toBe(true)
   expect(result.data).toBeNull()
+})
+
+it('treats a whitespace-only file as empty settings, preserving the raw text', () => {
+  const file = join(dir, 'settings.json')
+  writeFileSync(file, '   \n  ')
+
+  const result = readSettings(file)
+
+  expect(result.exists).toBe(true)
+  expect(result.data).toEqual({})
+  expect(result.raw).toBe('   \n  ')
+})
+
+it('parses a valid settings file, exposing both the data and its raw text', () => {
+  const file = join(dir, 'settings.json')
+  const settings = {
+    statusLine: { type: 'command', command: 'bash tokenline.sh' },
+  }
+  const raw = JSON.stringify(settings)
+  writeFileSync(file, raw)
+
+  const result = readSettings(file)
+
+  expect(result.exists).toBe(true)
+  expect(result.data).toEqual(settings)
+  expect(result.raw).toBe(raw)
 })


### PR DESCRIPTION
Closes #38.

## What this does

Completes the seed spec's coverage of `readSettings` — it now exercises all
four of the function's logical branches instead of two.

## Why

The seed spec added in #36 deliberately covered only the two hardest branches
(missing file; invalid JSON → `data: null`, "never clobber"). Since the seed
doubles as the pattern future specs copy, a *complete* example of testing one
function reads better than a half-covered one. The two remaining branches are
cheap to add and independent of #35's scope (`isTokenlineCommand`, `backup`),
so #35 stays focused.

## Changes

Two `it` blocks added to `src/core/settings.spec.ts`, reusing the existing
temp-dir pattern:

- **whitespace-only file** → `exists: true`, `data` equals `{}`, `raw` preserved.
- **valid JSON** → `exists: true`, `data` equals the parsed object, `raw` matches.

The header comment is updated to describe all four branches.

## Verification

- `pnpm test` — 4 passing (was 2).
- `pnpm lint`, `pnpm typecheck`, `pnpm build` — all green; no spec leaks into
  `dist/` (tsup bundles from `src/cli.ts` only).
