### PR TITLE
fix: convert rate-limit resets_at to epoch before ETA/pace math

### DIFF
--- a/tokenline.sh
+++ b/tokenline.sh
@@ -108,9 +108,9 @@ parse_and_prepare_paths() {
   transcript_path="${_f[3]}"
   session_id="${_f[4]}"
   rl_5h_pct="${_f[5]}"
-  rl_5h_reset="${_f[6]}"
+  rl_5h_reset=$(epoch_from_iso "${_f[6]}")
   rl_7d_pct="${_f[7]}"
-  rl_7d_reset="${_f[8]}"
+  rl_7d_reset=$(epoch_from_iso "${_f[8]}")
   cur_input="${_f[9]}"
   cur_output="${_f[10]}"
   cur_cwrite="${_f[11]}"


### PR DESCRIPTION
## The bug

The `five_hour` / `seven_day` `resets_at` values are read straight from `jq` as raw ISO-8601 strings (`rl_5h_reset` / `rl_7d_reset` at `tokenline.sh:111,113`) and passed **unconverted** into `rl_segment`, which does integer arithmetic on them:

```sh
eta_secs=$((reset_at - now_ts))   # reset_at = "2026-07-05T18:00:00Z"
```

`bash` can't evaluate `2026-07-05T18:00:00Z` as a number, so the subtraction throws `value too great for base` and the whole rate-limit line (window 3) collapses to empty — no ETA, no pace marker. `epoch_from_iso` already exists and is correctly applied to the transcript timestamp (`:210`); it was just never applied to the rate-limit resets.

## The fix

Two lines — run the resets through the existing `epoch_from_iso` at read time, mirroring how the transcript timestamp is handled:

```sh
rl_5h_reset=$(epoch_from_iso "${_f[6]}")
rl_7d_reset=$(epoch_from_iso "${_f[8]}")
```

Empty / absent resets stay empty (`epoch_from_iso`'s `2>/dev/null` swallows the failure), so inputs without rate limits (e.g. Gemini) are unaffected.

## Verification

Ran the script against a real snapshot on GNU/Linux with a fixed clock. **Before:** two lines, arithmetic error on stderr, no rate-limit line. **After:**

```
Opus 4.8 | ctx: 88.8k/1.0M (9%) | [5m] cache: 5:00 HOT
read(0.1x): 86.6k write(1.25x): 2.2k new(1x): 2 output(5x): 2.0k eq: 21.4k saving: 78%
──────────────────────────────
5h: █░░░░░░░░░ 12% (3d4h to reset)  7d: ██████░░░░ 64% (3d22h to reset) !
```

ShellCheck clean (`shellcheck -s bash`).

## Context

Found while building the byte-exact bash oracle for the Rust rewrite (#27) — the rewrite's parity tests need `tokenline.sh` to render the rate-limit line correctly. Landing this as a standalone fix first so the oracle is faithful.
