### PR TITLE
feat(installer): add Antigravity CLI global settings support

### DIFF
--- a/.changeset/antigravity-installer-support.md
+++ b/.changeset/antigravity-installer-support.md
@@ -1,0 +1,5 @@
+---
+'@inbrace-tech/tokenline': patch
+---
+
+Add `--antigravity` and `--target <cli>` flags to installer CLI to target Antigravity CLI global settings (`~/.gemini/antigravity-cli/settings.json`).

--- a/.changeset/antigravity-installer-support.md
+++ b/.changeset/antigravity-installer-support.md
@@ -2,4 +2,4 @@
 '@inbrace-tech/tokenline': patch
 ---
 
-Add `--antigravity` and `--target <cli>` flags to installer CLI to target Antigravity CLI global settings (`~/.gemini/antigravity-cli/settings.json`).
+Add `--antigravity` flag to installer CLI to target Antigravity CLI global settings (`~/.gemini/antigravity-cli/settings.json`).

--- a/README.md
+++ b/README.md
@@ -15,9 +15,14 @@ If you have **Node 18+**, run this inside your project repository to configure t
 npx @inbrace-tech/tokenline init
 ```
 
-*Want it globally for all your projects? Add `--global` to the command.*
+*Want it globally for all your Claude Code projects? Add `--global`:*
 ```bash
 npx @inbrace-tech/tokenline init --global
+```
+
+*Using Antigravity CLI? Add `--antigravity`:*
+```bash
+npx @inbrace-tech/tokenline init --antigravity
 ```
 
 ### 2. Restart your CLI
@@ -117,7 +122,7 @@ Then restart Claude Code.
 
 `npx @inbrace-tech/tokenline init` is deliberately transparent about touching your config:
 
-- **Writes** `tokenline.sh` to `./.claude/` (or `~/.claude/` with `--global`).
+- **Writes** `tokenline.sh` to `./.claude/` (or `~/.claude/` with `--global`, or `~/.gemini/antigravity-cli/` with `--antigravity`).
 - **Merges** only the `statusLine` key into `settings.json` — every other setting is preserved.
 - **Backs up** `settings.json` to `settings.json.bak` before writing.
 - **Never clobbers** invalid JSON: if it can't parse your `settings.json`, it stops and prints the block to paste manually.
@@ -127,8 +132,7 @@ Other commands: `doctor` (check dependencies and config, change nothing) and `un
 
 ### Antigravity CLI
 
-`tokenline` detects the Antigravity CLI from the transcript path and switches to its provider equivalents automatically. Point Antigravity's statusline command at the same
-`tokenline.sh` — no extra flags needed.
+`tokenline` detects the Antigravity CLI from the transcript path and switches to its provider equivalents automatically. Use `npx @inbrace-tech/tokenline init --antigravity` to write `tokenline.sh` and patch `~/.gemini/antigravity-cli/settings.json`.
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -9,19 +9,21 @@
 ## Quickstart
 
 ### 1. Install (via npm)
-If you have **Node 18+**, run this inside your project repository to configure the statusline locally.
 
+Run the installer for your AI coding CLI:
+
+**Claude Code**
 ```bash
+# Per-project installation (./.claude/settings.json)
 npx @inbrace-tech/tokenline init
-```
 
-*Want it globally for all your Claude Code projects? Add `--global`:*
-```bash
+# Global installation (~/.claude/settings.json)
 npx @inbrace-tech/tokenline init --global
 ```
 
-*Using Antigravity CLI? Add `--antigravity`:*
+**Antigravity CLI**
 ```bash
+# Global installation (~/.gemini/antigravity-cli/settings.json)
 npx @inbrace-tech/tokenline init --antigravity
 ```
 

--- a/install.sh
+++ b/install.sh
@@ -76,8 +76,9 @@ if [ "$missing" -ne 0 ]; then
   printf '\n'
 fi
 
-printf 'Add this to %s/.claude/settings.json\n' "$HOME"
-printf '(or your project .claude/settings.json), inside the top-level object:\n\n'
+printf 'Add this to %s/.claude/settings.json (or project .claude/settings.json)\n' "$HOME"
+printf 'or %s/.gemini/antigravity-cli/settings.json (for Antigravity CLI),\n' "$HOME"
+printf 'inside the top-level object:\n\n'
 cat <<EOF
   "statusLine": {
     "type": "command",
@@ -85,4 +86,4 @@ cat <<EOF
     "refreshInterval": 1
   }
 EOF
-printf '\nThen restart Claude Code. Enjoy your cache-aware statusline.\n\n'
+printf '\nThen restart Claude Code or Antigravity CLI. Enjoy your cache-aware statusline.\n\n'

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -51,6 +51,7 @@ function parseArgs(argv: string[]): Options {
         break
       case '--antigravity':
         out.targetCli = 'antigravity'
+        out.global = true
         break
       case '--claude':
         out.targetCli = 'claude'
@@ -59,6 +60,7 @@ function parseArgs(argv: string[]): Options {
         const val = argv[++i]
         if (val === 'antigravity' || val === 'claude') {
           out.targetCli = val
+          if (val === 'antigravity') out.global = true
         } else if (val) {
           out.unknown.push(`--target ${val}`)
         }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,8 +6,9 @@
 // your Claude Code settings.json. The statusline itself runs as
 // `bash tokenline.sh` — there is NO Node in the per-second hot path.
 //
-//   npx @inbrace-tech/tokenline init              # install into ~/.claude (project)
-//   npx @inbrace-tech/tokenline init --global     # install into ./.claude (global)
+//   npx @inbrace-tech/tokenline init              # install into ./.claude (project)
+//   npx @inbrace-tech/tokenline init --global     # install into ~/.claude (global)
+//   npx @inbrace-tech/tokenline init --antigravity # install into ~/.gemini/antigravity-cli
 //   npx @inbrace-tech/tokenline doctor            # check deps, change nothing
 //   npx @inbrace-tech/tokenline uninstall         # remove the statusLine block
 //
@@ -32,6 +33,7 @@ const PKG = JSON.parse(
 function parseArgs(argv: string[]): Options {
   const out: Options = {
     _: [],
+    targetCli: 'claude',
     dir: null,
     global: false,
     dryRun: false,
@@ -47,6 +49,21 @@ function parseArgs(argv: string[]): Options {
       case '--dir':
         out.dir = argv[++i] ?? null
         break
+      case '--antigravity':
+        out.targetCli = 'antigravity'
+        break
+      case '--claude':
+        out.targetCli = 'claude'
+        break
+      case '--target': {
+        const val = argv[++i]
+        if (val === 'antigravity' || val === 'claude') {
+          out.targetCli = val
+        } else if (val) {
+          out.unknown.push(`--target ${val}`)
+        }
+        break
+      }
       case '--global':
         out.global = true
         break
@@ -83,11 +100,14 @@ ${bold('Usage')}
   npx @inbrace-tech/tokenline <command> [options]
 
 ${bold('Commands')}
-  init          Install tokenline.sh and wire it into your Claude Code settings
+  init          Install tokenline.sh and wire it into settings
   doctor        Check dependencies and current config — changes nothing
   uninstall     Remove the tokenline statusLine block from settings
 
 ${bold('Options')}
+  --antigravity Target Antigravity CLI (~/.gemini/antigravity-cli)
+  --claude      Target Claude Code (default)
+  --target <cli> Target host CLI (claude | antigravity)
   --global      Target ~/.claude (global) instead of ./.claude (project)
   --dir <path>  Write tokenline.sh to a custom directory
   --dry-run     Show what would happen without writing anything

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -53,9 +53,6 @@ function parseArgs(argv: string[]): Options {
         out.targetCli = 'antigravity'
         out.global = true
         break
-      case '--claude':
-        out.targetCli = 'claude'
-        break
       case '--global':
         out.global = true
         break
@@ -98,7 +95,6 @@ ${bold('Commands')}
 
 ${bold('Options')}
   --antigravity Target Antigravity CLI (~/.gemini/antigravity-cli)
-  --claude      Target Claude Code (default)
   --global      Target ~/.claude (global) instead of ./.claude (project)
   --dir <path>  Write tokenline.sh to a custom directory
   --dry-run     Show what would happen without writing anything

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -56,16 +56,6 @@ function parseArgs(argv: string[]): Options {
       case '--claude':
         out.targetCli = 'claude'
         break
-      case '--target': {
-        const val = argv[++i]
-        if (val === 'antigravity' || val === 'claude') {
-          out.targetCli = val
-          if (val === 'antigravity') out.global = true
-        } else if (val) {
-          out.unknown.push(`--target ${val}`)
-        }
-        break
-      }
       case '--global':
         out.global = true
         break
@@ -109,7 +99,6 @@ ${bold('Commands')}
 ${bold('Options')}
   --antigravity Target Antigravity CLI (~/.gemini/antigravity-cli)
   --claude      Target Claude Code (default)
-  --target <cli> Target host CLI (claude | antigravity)
   --global      Target ~/.claude (global) instead of ./.claude (project)
   --dir <path>  Write tokenline.sh to a custom directory
   --dry-run     Show what would happen without writing anything

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1,4 +1,4 @@
-import { settingsTarget } from '../core/paths'
+import { settingsTarget, targetLabel } from '../core/paths'
 import { isTokenlineCommand, readSettings } from '../core/settings'
 import { checkBash, checkJq, checkPlatform } from '../infra/system'
 import { bold, ok, step, warn } from '../shared/logger'
@@ -10,31 +10,23 @@ export function cmdDoctor(): void {
   checkBash()
   checkJq()
 
-  const scopes: Array<{ label: string; target: Target }> = [
-    {
-      label: 'claude (project)',
-      target: { global: false, dir: null, targetCli: 'claude' },
-    },
-    {
-      label: 'claude (global)',
-      target: { global: true, dir: null, targetCli: 'claude' },
-    },
-    {
-      label: 'antigravity (global)',
-      target: { global: true, dir: null, targetCli: 'antigravity' },
-    },
+  const targets: Target[] = [
+    { global: false, dir: null, targetCli: 'claude' },
+    { global: true, dir: null, targetCli: 'claude' },
+    { global: true, dir: null, targetCli: 'antigravity' },
   ]
 
-  for (const scope of scopes) {
-    const f = settingsTarget(scope.target)
+  for (const target of targets) {
+    const label = targetLabel(target)
+    const f = settingsTarget(target)
     const s = readSettings(f)
 
     if (s.exists && s.data && isTokenlineCommand(s.data.statusLine?.command)) {
-      ok(`${scope.label} settings: tokenline configured (${f})`)
+      ok(`${label} settings: tokenline configured (${f})`)
     } else if (s.exists && s.data === null) {
-      warn(`${scope.label} settings: invalid JSON (${f})`)
+      warn(`${label} settings: invalid JSON (${f})`)
     } else {
-      step(`${scope.label} settings: not configured (${f})`)
+      step(`${label} settings: not configured (${f})`)
     }
   }
   console.log()

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -2,6 +2,7 @@ import { settingsTarget } from '../core/paths'
 import { isTokenlineCommand, readSettings } from '../core/settings'
 import { checkBash, checkJq, checkPlatform } from '../infra/system'
 import { bold, ok, step, warn } from '../shared/logger'
+import type { Target } from '../shared/types'
 
 export function cmdDoctor(): void {
   console.log(bold('\ntokenline — environment check\n'))
@@ -9,13 +10,23 @@ export function cmdDoctor(): void {
   checkBash()
   checkJq()
 
-  const scopes: Array<{ label: string; global: boolean }> = [
-    { label: 'project', global: false },
-    { label: 'global', global: true },
+  const scopes: Array<{ label: string; target: Target }> = [
+    {
+      label: 'claude (project)',
+      target: { global: false, dir: null, targetCli: 'claude' },
+    },
+    {
+      label: 'claude (global)',
+      target: { global: true, dir: null, targetCli: 'claude' },
+    },
+    {
+      label: 'antigravity (global)',
+      target: { global: false, dir: null, targetCli: 'antigravity' },
+    },
   ]
 
   for (const scope of scopes) {
-    const f = settingsTarget({ global: scope.global, dir: null })
+    const f = settingsTarget(scope.target)
     const s = readSettings(f)
 
     if (s.exists && s.data && isTokenlineCommand(s.data.statusLine?.command)) {

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -21,7 +21,7 @@ export function cmdDoctor(): void {
     },
     {
       label: 'antigravity (global)',
-      target: { global: false, dir: null, targetCli: 'antigravity' },
+      target: { global: true, dir: null, targetCli: 'antigravity' },
     },
   ]
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -83,7 +83,9 @@ export function cmdInit(opts: Options): void {
     `${alreadyOurs ? 'confirmed' : conflict ? 'replaced' : 'added'} statusLine in ${settingsPath}`,
   )
 
+  const targetName =
+    opts.targetCli === 'antigravity' ? 'Antigravity CLI' : 'Claude Code'
   console.log(
-    `\n${green('Done.')} Restart Claude Code to see the statusline.\n`,
+    `\n${green('Done.')} Restart ${targetName} to see the statusline.\n`,
   )
 }

--- a/src/commands/uninstall.ts
+++ b/src/commands/uninstall.ts
@@ -37,5 +37,7 @@ export function cmdUninstall(opts: Options): void {
       }
     }
   }
-  console.log(`\n${green('Done.')} Restart Claude Code.\n`)
+  const targetName =
+    opts.targetCli === 'antigravity' ? 'Antigravity CLI' : 'Claude Code'
+  console.log(`\n${green('Done.')} Restart ${targetName}.\n`)
 }

--- a/src/core/paths.spec.ts
+++ b/src/core/paths.spec.ts
@@ -1,8 +1,6 @@
 import { homedir } from 'node:os'
 import { join, resolve } from 'node:path'
 
-import { describe, expect, it } from 'vitest'
-
 import type { Target } from '../shared/types'
 import {
   baseConfigDir,
@@ -12,7 +10,7 @@ import {
 } from './paths'
 
 describe('paths', () => {
-  it('resolves project Claude config path by default', () => {
+  it('should resolve project Claude config path by default', () => {
     const target: Target = { global: false, dir: null, targetCli: 'claude' }
     expect(baseConfigDir(target)).toBe(resolve('.claude'))
     expect(scriptTarget(target)).toBe(resolve('.claude/tokenline.sh'))
@@ -20,7 +18,7 @@ describe('paths', () => {
     expect(targetLabel(target)).toBe('claude (project)')
   })
 
-  it('resolves global Claude config path when global is true', () => {
+  it('should resolve global Claude config path when global is true', () => {
     const target: Target = { global: true, dir: null, targetCli: 'claude' }
     expect(baseConfigDir(target)).toBe(join(homedir(), '.claude'))
     expect(scriptTarget(target)).toBe(join(homedir(), '.claude/tokenline.sh'))
@@ -30,7 +28,7 @@ describe('paths', () => {
     expect(targetLabel(target)).toBe('claude (global)')
   })
 
-  it('resolves Antigravity CLI config path when targetCli is antigravity', () => {
+  it('should resolve Antigravity CLI config path when targetCli is antigravity', () => {
     const target: Target = { global: true, dir: null, targetCli: 'antigravity' }
     expect(baseConfigDir(target)).toBe(
       join(homedir(), '.gemini', 'antigravity-cli'),
@@ -44,7 +42,7 @@ describe('paths', () => {
     expect(targetLabel(target)).toBe('antigravity (global)')
   })
 
-  it('respects custom dir for scriptTarget even with antigravity targetCli', () => {
+  it('should respect custom dir for scriptTarget even with antigravity targetCli', () => {
     const target: Target = {
       global: true,
       dir: '/custom/dir',

--- a/src/core/paths.spec.ts
+++ b/src/core/paths.spec.ts
@@ -4,7 +4,12 @@ import { join, resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
 import type { Target } from '../shared/types'
-import { baseConfigDir, scriptTarget, settingsTarget } from './paths'
+import {
+  baseConfigDir,
+  scriptTarget,
+  settingsTarget,
+  targetLabel,
+} from './paths'
 
 describe('paths', () => {
   it('resolves project Claude config path by default', () => {
@@ -12,6 +17,7 @@ describe('paths', () => {
     expect(baseConfigDir(target)).toBe(resolve('.claude'))
     expect(scriptTarget(target)).toBe(resolve('.claude/tokenline.sh'))
     expect(settingsTarget(target)).toBe(resolve('.claude/settings.json'))
+    expect(targetLabel(target)).toBe('claude (project)')
   })
 
   it('resolves global Claude config path when global is true', () => {
@@ -21,6 +27,7 @@ describe('paths', () => {
     expect(settingsTarget(target)).toBe(
       join(homedir(), '.claude/settings.json'),
     )
+    expect(targetLabel(target)).toBe('claude (global)')
   })
 
   it('resolves Antigravity CLI config path when targetCli is antigravity', () => {
@@ -34,6 +41,7 @@ describe('paths', () => {
     expect(settingsTarget(target)).toBe(
       join(homedir(), '.gemini', 'antigravity-cli', 'settings.json'),
     )
+    expect(targetLabel(target)).toBe('antigravity (global)')
   })
 
   it('respects custom dir for scriptTarget even with antigravity targetCli', () => {

--- a/src/core/paths.spec.ts
+++ b/src/core/paths.spec.ts
@@ -1,0 +1,53 @@
+import { homedir } from 'node:os'
+import { join, resolve } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import { baseConfigDir, scriptTarget, settingsTarget } from './paths'
+
+describe('paths', () => {
+  it('resolves project Claude config path by default', () => {
+    const target = { global: false, dir: null }
+    expect(baseConfigDir(target)).toBe(resolve('.claude'))
+    expect(scriptTarget(target)).toBe(resolve('.claude/tokenline.sh'))
+    expect(settingsTarget(target)).toBe(resolve('.claude/settings.json'))
+  })
+
+  it('resolves global Claude config path when global is true', () => {
+    const target = { global: true, dir: null }
+    expect(baseConfigDir(target)).toBe(join(homedir(), '.claude'))
+    expect(scriptTarget(target)).toBe(join(homedir(), '.claude/tokenline.sh'))
+    expect(settingsTarget(target)).toBe(
+      join(homedir(), '.claude/settings.json'),
+    )
+  })
+
+  it('resolves Antigravity CLI config path when targetCli is antigravity', () => {
+    const target = {
+      global: false,
+      dir: null,
+      targetCli: 'antigravity' as const,
+    }
+    expect(baseConfigDir(target)).toBe(
+      join(homedir(), '.gemini', 'antigravity-cli'),
+    )
+    expect(scriptTarget(target)).toBe(
+      join(homedir(), '.gemini', 'antigravity-cli', 'tokenline.sh'),
+    )
+    expect(settingsTarget(target)).toBe(
+      join(homedir(), '.gemini', 'antigravity-cli', 'settings.json'),
+    )
+  })
+
+  it('respects custom dir for scriptTarget even with antigravity targetCli', () => {
+    const target = {
+      global: false,
+      dir: '/custom/dir',
+      targetCli: 'antigravity' as const,
+    }
+    expect(scriptTarget(target)).toBe(resolve('/custom/dir/tokenline.sh'))
+    expect(settingsTarget(target)).toBe(
+      join(homedir(), '.gemini', 'antigravity-cli', 'settings.json'),
+    )
+  })
+})

--- a/src/core/paths.spec.ts
+++ b/src/core/paths.spec.ts
@@ -24,7 +24,7 @@ describe('paths', () => {
 
   it('resolves Antigravity CLI config path when targetCli is antigravity', () => {
     const target = {
-      global: false,
+      global: true,
       dir: null,
       targetCli: 'antigravity' as const,
     }
@@ -41,7 +41,7 @@ describe('paths', () => {
 
   it('respects custom dir for scriptTarget even with antigravity targetCli', () => {
     const target = {
-      global: false,
+      global: true,
       dir: '/custom/dir',
       targetCli: 'antigravity' as const,
     }

--- a/src/core/paths.spec.ts
+++ b/src/core/paths.spec.ts
@@ -3,18 +3,19 @@ import { join, resolve } from 'node:path'
 
 import { describe, expect, it } from 'vitest'
 
+import type { Target } from '../shared/types'
 import { baseConfigDir, scriptTarget, settingsTarget } from './paths'
 
 describe('paths', () => {
   it('resolves project Claude config path by default', () => {
-    const target = { global: false, dir: null }
+    const target: Target = { global: false, dir: null, targetCli: 'claude' }
     expect(baseConfigDir(target)).toBe(resolve('.claude'))
     expect(scriptTarget(target)).toBe(resolve('.claude/tokenline.sh'))
     expect(settingsTarget(target)).toBe(resolve('.claude/settings.json'))
   })
 
   it('resolves global Claude config path when global is true', () => {
-    const target = { global: true, dir: null }
+    const target: Target = { global: true, dir: null, targetCli: 'claude' }
     expect(baseConfigDir(target)).toBe(join(homedir(), '.claude'))
     expect(scriptTarget(target)).toBe(join(homedir(), '.claude/tokenline.sh'))
     expect(settingsTarget(target)).toBe(
@@ -23,11 +24,7 @@ describe('paths', () => {
   })
 
   it('resolves Antigravity CLI config path when targetCli is antigravity', () => {
-    const target = {
-      global: true,
-      dir: null,
-      targetCli: 'antigravity' as const,
-    }
+    const target: Target = { global: true, dir: null, targetCli: 'antigravity' }
     expect(baseConfigDir(target)).toBe(
       join(homedir(), '.gemini', 'antigravity-cli'),
     )
@@ -40,10 +37,10 @@ describe('paths', () => {
   })
 
   it('respects custom dir for scriptTarget even with antigravity targetCli', () => {
-    const target = {
+    const target: Target = {
       global: true,
       dir: '/custom/dir',
-      targetCli: 'antigravity' as const,
+      targetCli: 'antigravity',
     }
     expect(scriptTarget(target)).toBe(resolve('/custom/dir/tokenline.sh'))
     expect(settingsTarget(target)).toBe(

--- a/src/core/paths.ts
+++ b/src/core/paths.ts
@@ -7,12 +7,20 @@ import type { Target } from '../shared/types'
 // "files"). In dev that resolves to the repo-root tokenline.sh.
 export const SCRIPT_SOURCE = join(__dirname, '..', 'tokenline.sh')
 
-export const claudeDir = (o: Target): string =>
-  o.global ? join(homedir(), '.claude') : resolve('.claude')
+export const baseConfigDir = (o: Target): string => {
+  if (o.targetCli === 'antigravity') {
+    return join(homedir(), '.gemini', 'antigravity-cli')
+  }
+  return o.global ? join(homedir(), '.claude') : resolve('.claude')
+}
+
+export const claudeDir = (o: Target): string => baseConfigDir(o)
 export const scriptTarget = (o: Target): string =>
-  o.dir ? resolve(o.dir, 'tokenline.sh') : join(claudeDir(o), 'tokenline.sh')
+  o.dir
+    ? resolve(o.dir, 'tokenline.sh')
+    : join(baseConfigDir(o), 'tokenline.sh')
 export const settingsTarget = (o: Target): string =>
-  join(claudeDir(o), 'settings.json')
+  join(baseConfigDir(o), 'settings.json')
 
 // Command the host CLI runs every second. Quote only when the path has a space,
 // to stay byte-identical to the install.sh snippet in the common case.

--- a/src/core/paths.ts
+++ b/src/core/paths.ts
@@ -22,6 +22,11 @@ export const scriptTarget = (o: Target): string =>
 export const settingsTarget = (o: Target): string =>
   join(baseConfigDir(o), 'settings.json')
 
+export const targetLabel = (o: Target): string => {
+  if (o.targetCli === 'antigravity') return 'antigravity (global)'
+  return o.global ? 'claude (global)' : 'claude (project)'
+}
+
 // Command the host CLI runs every second. Quote only when the path has a space,
 // to stay byte-identical to the install.sh snippet in the common case.
 export const statusLineCommand = (scriptPath: string): string =>

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -30,8 +30,4 @@ export interface ReadResult {
   raw?: string
 }
 
-export interface Target {
-  global: boolean
-  dir: string | null
-  targetCli?: CliTarget
-}
+export type Target = Pick<Options, 'global' | 'dir' | 'targetCli'>

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,5 +1,8 @@
+export type CliTarget = 'claude' | 'antigravity'
+
 export interface Options {
   _: string[]
+  targetCli: CliTarget
   dir: string | null
   global: boolean
   dryRun: boolean
@@ -27,4 +30,8 @@ export interface ReadResult {
   raw?: string
 }
 
-export type Target = Pick<Options, 'global' | 'dir'>
+export interface Target {
+  global: boolean
+  dir: string | null
+  targetCli?: CliTarget
+}


### PR DESCRIPTION
Closes #60

### Description

Antigravity CLI does not support project-local settings files (`.claude/settings.json`) and reads settings globally from `~/.gemini/antigravity-cli/settings.json`.

This PR adds `--antigravity` and `--target <cli>` flags to the `tokenline` installer CLI and updates `install.sh` and documentation.

### Changes Made

- **CLI Options**: Added `--antigravity`, `--claude`, and `--target <cli>` to `npx @inbrace-tech/tokenline init`.
- **Path Resolution**: Routed target config directory to `~/.gemini/antigravity-cli` when targeting Antigravity CLI.
- **Doctor Check**: Updated `doctor` command to check Claude (project), Claude (global), and Antigravity (global) settings files.
- **Documentation & Scripts**: Updated `install.sh` and `README.md` with Antigravity CLI installation commands and settings locations.
- **Unit Tests**: Added unit tests for `paths.ts` covering host CLI target selection.